### PR TITLE
remove malformatted red star from ui-name field

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.1.0
+    1.1.1
 
 owners:
     [seaver]

--- a/ui/narrative/methods/runFastQC/display.yaml
+++ b/ui/narrative/methods/runFastQC/display.yaml
@@ -31,7 +31,7 @@ suggestions:
 parameters :
     input_file_ref :
         ui-name : |
-            Read Library/RNA-seq Sample Set <font color=red>*</font.
+            Read Library/RNA-seq Sample Set
         short-hint : |
             Select the Read Library or RNA-seq Sample Set to run quality control on.
 

--- a/ui/narrative/methods/runFastQC/spec.json
+++ b/ui/narrative/methods/runFastQC/spec.json
@@ -1,5 +1,5 @@
 {
-    "ver": "0.0.1",
+    "ver": "0.0.2",
     "authors": [
         "seaver"
     ],
@@ -9,7 +9,7 @@
         "input": null,
         "output": "no-display"
     },
-    "parameters": [ 
+    "parameters": [
         {
             "id": "input_file_ref",
             "optional": false,


### PR DESCRIPTION
This isn't necessary, as the Narrative produces a little * when a field is required.
Also, it's malformed HTML, and was causing pretty severe problems.